### PR TITLE
fix: fix mergeplots exponential embed growth and inject function_list…

### DIFF
--- a/assessment/macros/graph.php
+++ b/assessment/macros/graph.php
@@ -923,6 +923,22 @@ function adddrawcommand($plot, $cmd) {
     return str_replace("' />", $cmd . $end, $plot);
 }
 
+function _mergeplots_extract_json_str($embed) {
+    $start = strpos($embed, 'drawPicture({');
+    if ($start === false) return null;
+    $jsonStart = $start + strlen('drawPicture(');
+    $depth = 0; $jsonEnd = -1;
+    for ($j = $jsonStart; $j < strlen($embed); $j++) {
+        if ($embed[$j] === '{') $depth++;
+        elseif ($embed[$j] === '}') {
+            $depth--;
+            if ($depth === 0) { $jsonEnd = $j; break; }
+        }
+    }
+    if ($jsonEnd === -1) return null;
+    return substr($embed, $jsonStart, $jsonEnd - $jsonStart + 1);
+}
+
 function mergeplots($plota) {
     $n = func_num_args();
     if ($n == 1) {
@@ -936,8 +952,26 @@ function mergeplots($plota) {
             $plota .= $newtext;
         } else {
             $plotb = preg_replace('/<span.*?<\/span>/', '', $plotb);
-            $newcmds = preg_replace('/^.*?initPicture\(.*?\);\s*(axes\(.*?\);)?(.*?)\'\s*\/>.*$/', '$2', $plotb);
-            $plota = str_replace("' />", trim($newcmds) . "' />", $plota);
+            $jsonStrB = _mergeplots_extract_json_str($plotb);
+            if ($jsonStrB !== null) {
+                // Both embeds are new-format (drawPicture JSON) — merge function lists
+                $jsonStrA = _mergeplots_extract_json_str($plota);
+                if ($jsonStrA !== null) {
+                    $jsonA = json_decode($jsonStrA, true);
+                    $jsonB = json_decode($jsonStrB, true);
+                    if ($jsonA !== null && $jsonB !== null &&
+                        isset($jsonA['functions']) && isset($jsonB['functions'])) {
+                        $jsonA['functions'] = array_merge($jsonA['functions'], $jsonB['functions']);
+                        $plota = str_replace($jsonStrA, json_encode($jsonA), $plota);
+                    }
+                }
+            } else {
+                // Legacy format — only merge if $plota is also legacy
+                if (strpos($plota, 'drawPicture({') === false) {
+                    $newcmds = preg_replace('/^.*?initPicture\(.*?\);\s*(axes\(.*?\);)?(.*?)\'\s*\/>.*$/', '$2', $plotb);
+                    $plota = str_replace("' />", trim($newcmds) . "' />", $plota);
+                }
+            }
         }
     }
     return $plota;

--- a/problems.php
+++ b/problems.php
@@ -238,6 +238,48 @@ function showplot_with_functions($funcs) { //optional arguments:  $xmin,$xmax,$y
 }
 
 
+/**
+ * Injects a function_list attribute into embed tags produced by showplot_with_functions.
+ * Each embed has script='drawPicture({JSON})'; this parses the JSON and builds a
+ * comma-separated function_list string that replace_graph_function_lists() in the
+ * Python backend can consume to produce human-readable <GraphData> blocks for LLMs.
+ *
+ * Supported function types serialised into function_list:
+ *   standard → "equation,color"
+ *   text     → "text,x,y,content,color"
+ *   dot      → "dot,x,y,style,color"
+ */
+function injectFunctionListAttributes($html) {
+    return preg_replace_callback(
+        "/<embed([^>]*)script='drawPicture\((\{[^']*\})\)'([^>]*)\/>/s",
+        function($m) {
+            $before  = $m[1]; $jsonStr = $m[2]; $after = $m[3];
+            $config = json_decode($jsonStr, true);
+            if (!$config || !isset($config['functions'])) return $m[0];
+            $list = [];
+            foreach ($config['functions'] as $f) {
+                $type = $f['type'] ?? '';
+                if ($type === 'standard') {
+                    $str = $f['equation'] ?? '';
+                    if (!empty($f['color'])) $str .= ',' . $f['color'];
+                    $list[] = $str;
+                } elseif ($type === 'text') {
+                    $str = 'text,' . ($f['x'] ?? '') . ',' . ($f['y'] ?? '') . ',' . ($f['content'] ?? '');
+                    if (!empty($f['color'])) $str .= ',' . $f['color'];
+                    $list[] = $str;
+                } elseif ($type === 'dot') {
+                    $str = 'dot,' . ($f['x'] ?? '') . ',' . ($f['y'] ?? '');
+                    if (!empty($f['style'])) $str .= ',' . $f['style'];
+                    if (!empty($f['color'])) $str .= ',' . $f['color'];
+                    $list[] = $str;
+                }
+            }
+            return "<embed{$before}function_list='" . json_encode($list) . "' script='drawPicture({$jsonStr})'{$after}/>";
+        },
+        $html
+    );
+}
+
 function processContent($matches) {
     $content = $matches[1];
     $processedContent = makepretty($content);
@@ -333,9 +375,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $question = $a2->getQuestion();
     $questionContent = $question->getQuestionContent();
 
+    if ($showplot === "fn") {
+        $questionContent = injectFunctionListAttributes($questionContent);
+    }
+
     if ($stype == "template") {
         $originalSolution = $question->getSolutionContent();
     } else {
+        $solutionCode = ($showplot === "fn")
+            ? str_replace("showplot", "showplot_with_functions", $solution)
+            : $solution;
         $vars = $question->getVarsOutput();
         $sanitizedVars = [];
         foreach ($vars as $key => $value) {
@@ -344,13 +393,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
         extract($sanitizedVars);
         ob_start();
-        eval($solution);
+        eval($solutionCode);
         $originalSolution = ob_get_clean();
+    }
+
+    if ($showplot === "fn") {
+        $originalSolution = injectFunctionListAttributes($originalSolution);
     }
 
     $prettySolution = preg_replace_callback('/`([^`]*)`/', 'processContent', $originalSolution);
 
     $answers = $question->getCorrectAnswersForParts();
+    if ($showplot === "fn") {
+        $answers = injectFunctionListAttributes($answers);
+    }
     $vars = $question->getVarsOutput();
     $jsparams = $disp["jsparams"];
 


### PR DESCRIPTION
… for showplot:fn mode

- assessment/macros/graph.php: add _mergeplots_extract_json_str() helper and rewrite mergeplots() else-branch to JSON-merge functions arrays when both plots are new-format showplot_with_functions embeds, preventing 2^N embed tag duplication (41MB response)
- problems.php: add injectFunctionListAttributes() that post-processes drawPicture embeds to add a function_list attribute (curve/text/dot entries) consumable by the Python backend's replace_graph_function_lists() for LLM-readable <GraphData> context; applied to question, solution, and answers when showplot=fn