### PR TITLE
fix: mergeplots leak when initPicture is absent from plotb

### DIFF
--- a/assessment/macros/graph.php
+++ b/assessment/macros/graph.php
@@ -1173,8 +1173,19 @@ function mergeplots($plota) {
             } else {
                 // Legacy format — only merge if $plota is also legacy
                 if (strpos($plota, 'drawPicture({') === false) {
-                    $newcmds = preg_replace('/^.*?initPicture\(.*?\);\s*(axes\(.*?\);)?(.*?)\'\s*\/>.*$/', '$2', $plotb);
-                    $plota = str_replace("' />", trim($newcmds) . "' />", $plota);
+                    // Pull the script attribute out of plotb directly. Older showplot()
+                    // emitted `setBorder(...); initPicture(...); axes(...); <draw cmds>`;
+                    // modern showplot() emits only `axes(...); <draw cmds>` (no initPicture).
+                    // Strip whichever boilerplate is present so plota's own setup is kept
+                    // and only the additional draw commands get appended.
+                    if (preg_match("/script='([^']*)'/", $plotb, $sm)) {
+                        $newcmds = preg_replace(
+                            '/^\s*(setBorder\([^)]*\);\s*)?(initPicture\([^)]*\);\s*)?(axes\([^)]*\);\s*)?/',
+                            '',
+                            $sm[1]
+                        );
+                        $plota = str_replace("' />", trim($newcmds) . "' />", $plota);
+                    }
                 }
             }
         }

--- a/assessment/macros/graph.php
+++ b/assessment/macros/graph.php
@@ -1179,8 +1179,10 @@ function mergeplots($plota) {
                     // Strip whichever boilerplate is present so plota's own setup is kept
                     // and only the additional draw commands get appended.
                     if (preg_match("/script='([^']*)'/", $plotb, $sm)) {
+                        // Leading `[;\s]*` also absorbs stray empty statements
+                        // (e.g. showplot() emits `;  initPicture(...)`).
                         $newcmds = preg_replace(
-                            '/^\s*(setBorder\([^)]*\);\s*)?(initPicture\([^)]*\);\s*)?(axes\([^)]*\);\s*)?/',
+                            '/^[;\s]*(setBorder\([^)]*\);\s*)?(initPicture\([^)]*\);\s*)?(axes\([^)]*\);\s*)?/',
                             '',
                             $sm[1]
                         );

--- a/tests/unit/AddlabelTest.php
+++ b/tests/unit/AddlabelTest.php
@@ -147,4 +147,80 @@ final class AddlabelTest extends TestCase
             'initPicture should not be duplicated after merge'
         );
     }
+
+    /**
+     * Modern showplot() emits embeds whose script attribute starts with
+     * `axes(...)` directly — no `setBorder(...);` or `initPicture(...);`
+     * prefix. mergeplots must still extract the additional draw commands
+     * and inject them into plota's script, without leaking the second
+     * embed tag as text.
+     */
+    public function testMergeplotsModernFormatInjectsCommands()
+    {
+        $plotA =
+            "<embed type='image/svg+xml' align='middle' width='500' height='500'" .
+            " function_list='[\"x^2\"]'" .
+            " plot-func='abc'" .
+            " script='axes(1,1,1,1,1);plot(\"x^2\");'" .
+            " />\n";
+        $plotB =
+            "<embed type='image/svg+xml' align='middle' width='500' height='500'" .
+            " function_list='[\"x^3\"]'" .
+            " plot-func='def'" .
+            " script='axes(1,1,1,1,1);plot(\"x^3\");'" .
+            " />\n";
+
+        $result = mergeplots($plotA, $plotB);
+
+        $this->assertRegExp(
+            "/script='[^']*plot\(\"x\^3\"\)/",
+            $result,
+            'plotB draw command should be inside plotA\'s script attribute'
+        );
+        $this->assertEquals(
+            1,
+            substr_count($result, '<embed'),
+            'merged result must be a single embed tag — no nested embed leaked into the script'
+        );
+    }
+
+    /**
+     * ineqbetweenplot() injects fill/path commands into a modern showplot()
+     * embed via str_replace("' />"). mergeplots() must merge such an embed
+     * with another modern embed without spilling the second embed's script
+     * payload as visible text below the graph.
+     */
+    public function testMergeplotsModernFormatWithIneqbetweenplotPayload()
+    {
+        $plotA =
+            "<embed type='image/svg+xml' align='middle' width='500' height='500'" .
+            " function_list='[]'" .
+            " plot-func='abc'" .
+            " script='axes(1,1,1,1,1);fill=\"transgreen\";strokewidth=0;path([[0,0],[1,0],[1,-3],[0,-3]]);'" .
+            " />\n";
+        $plotB =
+            "<embed type='image/svg+xml' align='middle' width='500' height='500'" .
+            " function_list='[\"line\"]'" .
+            " plot-func='def'" .
+            " script='axes(1,1,1,1,1);plot(\"x\");'" .
+            " />\n";
+
+        $result = mergeplots($plotA, $plotB);
+
+        $this->assertEquals(
+            1,
+            substr_count($result, '<embed'),
+            'merged result must be a single embed tag'
+        );
+        $this->assertRegExp(
+            "/script='[^']*path\(\[\[0,0\]/",
+            $result,
+            'fill/path payload from ineqbetweenplot must remain in script'
+        );
+        $this->assertRegExp(
+            "/script='[^']*plot\(\"x\"\)/",
+            $result,
+            'plotB plot() must be appended into plotA\'s script'
+        );
+    }
 }

--- a/tests/unit/AddlabelTest.php
+++ b/tests/unit/AddlabelTest.php
@@ -223,4 +223,41 @@ final class AddlabelTest extends TestCase
             'plotB plot() must be appended into plotA\'s script'
         );
     }
+
+    /**
+     * showplot() can emit a script whose payload begins with a stray empty
+     * statement, e.g. `;  initPicture(...); axes(...);; stroke = "red";; plot(...)`.
+     * The leading `;` must not block the setBorder/initPicture/axes strip;
+     * otherwise the duplicate initPicture re-runs and clears the canvas.
+     */
+    public function testMergeplotsStripsBoilerplateWithLeadingSemicolon()
+    {
+        $plotA =
+            "<embed type='image/svg+xml' align='middle' width='400' height='400'" .
+            " script=';  initPicture(-2.5,2.5,-2.5,2.5); axes(1, 1, \"labels\", );;  stroke = \"blue\";;  plot(\"x\",0,1)' />\n";
+        $plotB =
+            "<embed type='image/svg+xml' align='middle' width='400' height='400'" .
+            " script=';  initPicture(-2.5,2.5,-2.5,2.5); axes(1, 1, \"labels\", );;  stroke = \"red\";;  plot(\"x\",1,2)' />\n";
+
+        $result = mergeplots($plotA, $plotB);
+
+        $this->assertEquals(
+            1,
+            substr_count($result, 'initPicture'),
+            'initPicture must not be duplicated when plotb starts with a stray semicolon'
+        );
+        $this->assertRegExp(
+            "/stroke = \"red\";;\s*plot\(\"x\",1,2\)/",
+            $result,
+            'plotB draw commands must still be injected into plotA'
+        );
+        // plotA's script ends with `...plot("x",0,1)` (no trailing `;`). The
+        // injected commands must be separated by `;` so they parse as a new
+        // statement — otherwise we'd get `...plot("x",0,1)stroke = "red"...`.
+        $this->assertNotRegExp(
+            "/plot\(\"x\",0,1\)stroke/",
+            $result,
+            'separator semicolon between plotA tail and injected plotB commands must be preserved'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- The legacy-format branch in `mergeplots()` required `initPicture(...)` in `plotb`'s script attribute. When merging an `ineqbetweenplot()` output with a modern `showplot()`-derived plot whose script lacked that prefix, `preg_replace` returned `plotb` verbatim and the entire second `<embed>` tag was injected into `plota`'s `script='…'` attribute. The browser then rendered the outer embed and showed the leaked inner script as fallback text below the graph.
- Fix: pull script content out of `plotb` directly with `preg_match`, then strip any `setBorder/initPicture/axes` prefix before appending. Works with both legacy (`setBorder; initPicture; axes; …`) and modern (`axes; …`) embed shapes.
- Repro is the question template that combines `ineqbetweenplot()` shaded regions with a `mergeplots()` of `showplot()` line segments — the explanation rendered the function graph correctly but spilled the SVG path commands as text below the plot.

## Test plan
- [x] `vendor/bin/codecept run unit AddlabelTest` — 10/10 pass; added two new cases that fail without the fix (single-`<embed>` invariant + ineqbetweenplot fill/path payload preservation)
- [x] `vendor/bin/codecept run unit DrawFunctionDescriptionTest` — 63/63 pass
- [x] Verified on a sample request to `problems.php` that the merged solution contains exactly one `<embed>` tag with all expected `path(...)` and `fill=...` commands concatenated into a single `script` attribute (no nested embed, no premature single-quote termination)
- [ ] Verify the original failing question template renders cleanly end-to-end in the labelling preview tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)